### PR TITLE
arm: zynq: remove reference to __aeabi_uldivmod

### DIFF
--- a/arch/arm/cpu/armv7/zynq/timer.c
+++ b/arch/arm/cpu/armv7/zynq/timer.c
@@ -123,8 +123,8 @@ void __udelay(unsigned long usec)
 	if (usec == 0)
 		return;
 
-	countticks = (u32) (((unsigned long long) TIMER_TICK_HZ * usec) /
-								1000000);
+	countticks = (u32) (lldiv(((unsigned long long) TIMER_TICK_HZ * usec),
+								1000000));
 
 	/* decrementing timer */
 	timeend = readl(&timer_base->counter) - countticks;


### PR DESCRIPTION
Toolchains may generate calls to __aeabi_uldivmod(), which is neither defined
in the toolchain libs nor u-boot source tree, causing linkage failure on build
due to the symbol being undefined.

As an alternative to the division operator, lldiv() is available for use with
64bit division, which is used in this patch. A "proper" implementation of
__aeabi_uldivmod for armv7 would be nice to have, though.

Please refer to 32fc16d7e7a81816ce247b7cd70c94f3210a228b for a similar,
accepted fix in ext4write code.

Signed-off-by: Dennis Herbrich <dennis.herbrich@hytera.de>