### PR TITLE
spi: zynq_qspi: fix slave max speed configuration

### DIFF
--- a/drivers/spi/zynq_qspi.c
+++ b/drivers/spi/zynq_qspi.c
@@ -910,7 +910,8 @@ struct spi_slave *spi_setup_slave(unsigned int bus, unsigned int cs,
 	qspi->slave.rd_cmd = READ_CMD_FULL;
 	qspi->slave.wr_cmd = PAGE_PROGRAM | QUAD_PAGE_PROGRAM;
 	qspi->qspi.master.speed_hz = qspi->qspi.master.input_clk_hz / 2;
-	qspi->qspi.max_speed_hz = qspi->qspi.master.speed_hz;
+	qspi->qspi.max_speed_hz = (max_hz < qspi->qspi.master.speed_hz) ?
+								max_hz : qspi->qspi.master.speed_hz;
 	qspi->qspi.master.is_dual = is_dual;
 	qspi->qspi.mode = mode;
 	qspi->qspi.chip_select = 0;


### PR DESCRIPTION
spi_setup_slave() was ignoring the slave max speed defined by
CONFIG_SF_DEFAULT_SPEED or provided at the command line by the user, and always
configuring the QSPI slave max speed to the QSPI master speed. This fix chooses
the QSPI slave max speed to be the minimum of the provided one (default
configuration or user supplied) and the QSPI master speed.

Signed-off-by: Ivan Sergeev <vsergeev@kumunetworks.com>