### PR TITLE
Zynq: Enable booting from unified image

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -365,6 +365,9 @@ endif
 ifneq ($(CONFIG_ZYNQ),)
 ifeq ($(CONFIG_SPL),y)
 ALL-y += $(obj)boot.bin
+ifeq ($(CONFIG_SPL_U_BOOT_APPEND),y)
+ALL-y += $(obj)u-boot-spl-unified.bin
+endif
 endif
 endif
 
@@ -514,6 +517,9 @@ $(obj)u-boot-img.bin: $(obj)spl/u-boot-spl.bin $(obj)u-boot.img
 
 $(obj)boot.bin: $(obj)spl/u-boot-spl.bin
 	tools/zynq-boot-bin.py -o $(obj)boot.bin -u $(obj)spl/u-boot-spl.bin
+
+$(obj)u-boot-spl-unified.bin: $(obj)boot.bin $(obj)u-boot.img
+	cat $(obj)boot.bin $(obj)u-boot.img > $@
 
 # PPC4xx needs the SPL at the end of the image, since the reset vector
 # is located at 0xfffffffc. So we can't use the "u-boot-img.bin" target

--- a/arch/arm/cpu/armv7/zynq/spl.c
+++ b/arch/arm/cpu/armv7/zynq/spl.c
@@ -5,6 +5,7 @@
  */
 #include <common.h>
 #include <spl.h>
+#include <spi_flash.h>
 
 #include <asm/io.h>
 #include <asm/arch/hardware.h>
@@ -84,5 +85,22 @@ int spl_start_uboot(void)
 {
 	/* boot linux */
 	return 0;
+}
+#endif
+
+#ifdef CONFIG_SPL_U_BOOT_APPEND
+u32 spl_spi_u_boot_offs(struct spi_flash *flash)
+{
+    u32 mbaddr;
+    u32 imglen;
+    u32 soff;
+
+    mbaddr = (devcfg_base->multiboot_addr & ZYNQ_MB_MASK) * ZYNQ_MB_OFFS;
+
+    /* Read BootROM fields and calculate u-boot offset */
+    spi_flash_read(flash, mbaddr + 0x40, sizeof(u32), (void*)&imglen);
+    spi_flash_read(flash, mbaddr + 0x30, sizeof(u32), (void*)&soff);
+
+    return mbaddr + imglen + soff;
 }
 #endif

--- a/arch/arm/cpu/armv7/zynq/u-boot-spl.lds
+++ b/arch/arm/cpu/armv7/zynq/u-boot-spl.lds
@@ -29,6 +29,9 @@ SECTIONS
 	. = ALIGN(4);
 	.data : {
 		*(.data*)
+#if defined(CONFIG_SPL_U_BOOT_APPEND)
+		. = ALIGN(4);
+#endif
 	}
 
 	. = ALIGN(4);

--- a/arch/arm/include/asm/arch-zynq/hardware.h
+++ b/arch/arm/include/asm/arch-zynq/hardware.h
@@ -37,6 +37,10 @@
 #define ZYNQ_BM_SD		0x05
 #define ZYNQ_BM_JTAG		0x0
 
+/* Multiboot defines */
+#define ZYNQ_MB_MASK    0x1FFF
+#define ZYNQ_MB_OFFS    0x8000
+
 /* Reflect slcr offsets */
 struct slcr_regs {
 	u32 scl; /* 0x0 */
@@ -112,7 +116,8 @@ struct devcfg_regs {
 	u32 dma_src_len; /* 0x20 */
 	u32 dma_dst_len; /* 0x24 */
 	u32 rom_shadow; /* 0x28 */
-	u32 reserved1[2];
+	u32 multiboot_addr; /* 0x2c */
+	u32 reserved1;
 	u32 unlock; /* 0x34 */
 	u32 reserved2[18];
 	u32 mctrl; /* 0x80 */

--- a/drivers/mtd/spi/spi_spl_load.c
+++ b/drivers/mtd/spi/spi_spl_load.c
@@ -13,6 +13,11 @@
 #include <spi_flash.h>
 #include <spl.h>
 
+__weak u32 spl_spi_u_boot_offs(struct spi_flash *flash)
+{
+    return CONFIG_SYS_SPI_U_BOOT_OFFS;
+}
+
 /*
  * The main entry for SPI booting. It's necessary that SDRAM is already
  * configured and available since this code loads the main U-Boot image
@@ -22,6 +27,7 @@ void spl_spi_load_image(void)
 {
 	struct spi_flash *flash;
 	struct image_header *header;
+	u32 offs;
 
 	/*
 	 * Load U-Boot image from SPI flash into RAM
@@ -38,9 +44,8 @@ void spl_spi_load_image(void)
 	header = (struct image_header *)(CONFIG_SYS_TEXT_BASE);
 
 	/* Load u-boot, mkimage header is 64 bytes. */
-	spi_flash_read(flash, CONFIG_SYS_SPI_U_BOOT_OFFS, 0x40,
-		       (void *)header);
+	offs = spl_spi_u_boot_offs(flash);
+	spi_flash_read(flash, offs, 0x40, (void *)header);
 	spl_parse_image_header(header);
-	spi_flash_read(flash, CONFIG_SYS_SPI_U_BOOT_OFFS,
-		       spl_image.size, (void *)spl_image.load_addr);
+	spi_flash_read(flash, offs, spl_image.size, (void *)spl_image.load_addr);
 }

--- a/include/configs/zynq_zc70x.h
+++ b/include/configs/zynq_zc70x.h
@@ -26,6 +26,8 @@
 #define CONFIG_ZYNQ_BOOT_FREEBSD
 #define CONFIG_DEFAULT_DEVICE_TREE	zynq-zc702
 
+#define CONFIG_SPL_U_BOOT_APPEND
+
 #include <configs/zynq-common.h>
 
 #endif /* __CONFIG_ZYNQ_ZC70X_H */


### PR DESCRIPTION
This change uses the multiboot address register
in the SPL to read fields from the BootROM header
in SPI flash and subsequently calculate an offset to 
the u-boot image which is appended to the SPL image.
This means we can have one image containing SPL and
u-boot instead of two.

I do not expect this commit to be merged as is, but maybe it can serve as a starting point for a discussion
on how this could best be implemented.
