### PR TITLE
Fix python version for zynq-boot-bin.py

### DIFF
--- a/tools/zynq-boot-bin.py
+++ b/tools/zynq-boot-bin.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 # -*- coding: utf-8 -*-
 # Copyright (C) 2014, Xilinx.inc.
 #


### PR DESCRIPTION
The code does not work when Python 3 is default.
Enforce using Python 2.