### PR TITLE
zynq: Specifies the python version requirement

### DIFF
--- a/tools/zynq-boot-bin.py
+++ b/tools/zynq-boot-bin.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 # -*- coding: utf-8 -*-
 # Copyright (C) 2014, Xilinx.inc.
 #


### PR DESCRIPTION
Explicitly specifies the usage of python 2 in the script to avoid error
on print usage.
