### PR TITLE
The preboot= is defined twice in the environment

### DIFF
--- a/include/configs/zynq-common.h
+++ b/include/configs/zynq-common.h
@@ -251,7 +251,7 @@
 #endif
 
 /* Default environment */
-#define CONFIG_PREBOOT
+#undef CONFIG_PREBOOT
 #define CONFIG_EXTRA_ENV_SETTINGS	\
 	"ethaddr=00:0a:35:00:01:22\0"	\
 	"kernel_image=uImage\0"	\


### PR DESCRIPTION
This change removes double definition of the preboot= in the default environment for the Zynq board.That double definition confuses the FreeBSD loader and causes it to stuck in the infinite loop iterating the variable set over and over again.