### PR TITLE
Set the NAND_NO_SUBPAGE_WRITE option in nand_chip.  

### DIFF
--- a/drivers/mtd/nand/zynq_nand.c
+++ b/drivers/mtd/nand/zynq_nand.c
@@ -1192,6 +1192,8 @@ static int zynq_nand_init(struct nand_chip *nand_chip, int devnum)
 		nand_chip->ecc.read_oob = zynq_nand_read_oob;
 		nand_chip->ecc.write_oob = zynq_nand_write_oob;
 
+		nand_chip->options |= NAND_NO_SUBPAGE_WRITE;
+
 		switch (mtd->writesize) {
 		case 512:
 			ecc_page_size = 0x1;


### PR DESCRIPTION
This allows write_page to be used for subpage writes
Otherwise hwctl is called, causing u-boot to crash and reset.
