### PR TITLE
Fixed CMD_ZYNQ_RSA dependency on a non-existent menu option

### DIFF
--- a/common/Kconfig
+++ b/common/Kconfig
@@ -502,8 +502,15 @@ config CMD_SETGETDCR
 	  getidcr - Get a register value via indirect DCR addressing
 	  setidcr - Set a register value via indirect DCR addressing
 
+config CMD_ZYNQ_AES
+	bool "Zynq AES"
+	help
+	  Decrypts the encrypted image present in source address
+	  and places the decrypted image at destination address
+
 config CMD_ZYNQ_RSA
 	bool "Zynq RSA"
+	depends on CMD_ZYNQ_AES
 	help
 	  Verifies the authenticated and encrypted zynq images.
 


### PR DESCRIPTION
u-boot-xlnx will fail to build when configured with support for the Zynq RSA command, enabled through the Command line interface --> Misc commands submenu. The build failure was due to Zynq RSA's dependency on Zynq AES being unmet when enabled via Kconfig menus. The resolution was to add another menu option to define CMD_ZYNQ_AES and then have the menu option for CMD_ZYNQ_RSA depend on the option for CMD_ZYNQ_AES being enabled.