### PR TITLE
xilinx_phy: Fix bug incorrect pointer

### DIFF
--- a/drivers/net/phy/xilinx_phy.c
+++ b/drivers/net/phy/xilinx_phy.c
@@ -101,11 +101,10 @@ static int xilinxphy_startup(struct phy_device *phydev)
 
 static int xilinxphy_of_init(struct phy_device *phydev)
 {
-	struct udevice *dev = (struct udevice *)&phydev->dev;
 	u32 phytype;
 
 	debug("%s\n", __func__);
-	phytype = fdtdec_get_int(gd->fdt_blob, dev->of_offset, "phy-type", -1);
+	phytype = fdtdec_get_int(gd->fdt_blob, phydev->dev->of_offset, "phy-type", -1);
 	if (phytype == XAE_PHY_TYPE_1000BASE_X)
 		phydev->flags |= XAE_PHY_TYPE_1000BASE_X;
 


### PR DESCRIPTION
This fix incorrect pointer on offset device in device tree blob.
When using with the component "Ethernet 1G/2.5G BASE-X PCS/PMA or SGMII"
he does not understand what type is XAE_PHY_TYPE_1000BASE_X and trying
to change frequency