### PR TITLE
armv8: zynqmp: Map PCIe High as device memory

### DIFF
--- a/arch/arm/cpu/armv8/zynqmp/cpu.c
+++ b/arch/arm/cpu/armv8/zynqmp/cpu.c
@@ -48,20 +48,20 @@ static struct mm_region zynqmp_mem_map[] = {
 #endif
 		.virt = 0x400000000UL,
 		.phys = 0x400000000UL,
-		.size = 0x200000000UL,
+		.size = 0x400000000UL,
 		.attrs = PTE_BLOCK_MEMTYPE(MT_DEVICE_NGNRNE) |
 			 PTE_BLOCK_NON_SHARE |
 			 PTE_BLOCK_PXN | PTE_BLOCK_UXN
 	}, {
-		.virt = 0x600000000UL,
-		.phys = 0x600000000UL,
+		.virt = 0x800000000UL,
+		.phys = 0x800000000UL,
 		.size = 0x800000000UL,
 		.attrs = PTE_BLOCK_MEMTYPE(MT_NORMAL) |
 			 PTE_BLOCK_INNER_SHARE
 	}, {
-		.virt = 0xe00000000UL,
-		.phys = 0xe00000000UL,
-		.size = 0xf200000000UL,
+		.virt = 0x1000000000UL,
+		.phys = 0x1000000000UL,
+		.size = 0xf000000000UL,
 		.attrs = PTE_BLOCK_MEMTYPE(MT_DEVICE_NGNRNE) |
 			 PTE_BLOCK_NON_SHARE |
 			 PTE_BLOCK_PXN | PTE_BLOCK_UXN


### PR DESCRIPTION
Set the 8GB PCIe High area as device memory.
Also extend the DDR High area to cover the full 32GB range.

Signed-off-by: Anders Hedlund <anders.j.hedlund@gmail.com>