### PR TITLE
SPANSION spi-nor flash OTP bits fix

### DIFF
--- a/drivers/mtd/spi/sf_internal.h
+++ b/drivers/mtd/spi/sf_internal.h
@@ -80,6 +80,7 @@ enum spi_nor_option_flags {
 /* Common status */
 #define STATUS_WIP			BIT(0)
 #define STATUS_QEB_WINSPAN		BIT(1)
+#define STATUS_LC_WINSPAN               (3 << 6)
 #define STATUS_QEB_MXIC			BIT(6)
 #define STATUS_PEC			BIT(7)
 #define SR_BP0				BIT(2)  /* Block protect 0 */

--- a/drivers/mtd/spi/spi_flash.c
+++ b/drivers/mtd/spi/spi_flash.c
@@ -1127,14 +1127,17 @@ static int spansion_quad_enable(struct spi_flash *flash)
 	}
 #endif
 
-	if ((qeb_status & STATUS_QEB_WINSPAN)
+	if ((qeb_status & STATUS_QEB_WINSPAN) &&
+	    !(qeb_status & STATUS_LC_WINSPAN)
 #ifdef CONFIG_SPI_GENERIC
 	    && (qeb_status_up & STATUS_QEB_WINSPAN)
 #endif
 	) {
 		debug("SF: winspan: QEB is already set\n");
 	} else {
-		ret = write_cr(flash, STATUS_QEB_WINSPAN);
+	  ret = write_cr(flash,
+			 (qeb_status & ~STATUS_LC_WINSPAN) |
+			 STATUS_QEB_WINSPAN);
 		if (ret < 0)
 			return ret;
 	}
@@ -1197,6 +1200,17 @@ static int set_quad_mode(struct spi_flash *flash,
 		       JEDEC_MFR(info));
 		return -1;
 	}
+}
+
+static int set_block_protection(struct spi_flash *flash, int bp)
+{
+  u8 sr_cr[2];
+
+  read_cr(flash, &sr_cr[1]);
+  read_sr(flash, &sr_cr[0]);
+  sr_cr[0] = ((sr_cr[0] & ~0x1c) | (0x1c & (bp << 2)));
+  return spi_flash_write_common(flash, &(u8){CMD_WRITE_STATUS},
+				1, &sr_cr, 2);
 }
 
 int spi_flash_cmd_4B_addr_switch(struct spi_flash *flash,
@@ -1385,6 +1399,10 @@ int spi_flash_scan(struct spi_flash *flash)
 		flash->erase_size = flash->sector_size;
 	}
 
+#if defined(CONFIG_SPI_FLASH_SPANSION)
+	set_block_protection(flash, 0); /* Force BP0-2 to zero */
+#endif
+	
 	/* Now erase size becomes valid sector size */
 	flash->sector_size = flash->erase_size;
 


### PR DESCRIPTION
If OTP bits are set to 1 in SPANSION flash CR1 register, controller will crash & boot will fail.
This is a small fix to ensure flash is readable anyway