### PR TITLE
Update sun50i-h5-nanopi-neo2.dts

### DIFF
--- a/arch/arm/dts/sun50i-h5-nanopi-neo2.dts
+++ b/arch/arm/dts/sun50i-h5-nanopi-neo2.dts
@@ -84,3 +84,15 @@
 	pinctrl-0 = <&uart0_pins_a>;
 	status = "okay";
 };
+
+&emac {
+        pinctrl-names = "default";
+        pinctrl-0 = <&emac_rgmii_pins>;
+        status = "okay";
+        phy = <&phy1>;
+        phy-mode = "rgmii";
+        phy1: ethernet-phy@1 {
+                reg = <0>;
+        };
+};
+


### PR DESCRIPTION
The &emac section that was added enables the ethernet network interface in u-boot, allowing u-boot to continue booting from the network.