### PR TITLE
net: phy: xilinx: fix SGMII duplex parsing from MII_LPA

### DIFF
--- a/drivers/net/phy/xilinx_phy.c
+++ b/drivers/net/phy/xilinx_phy.c
@@ -45,13 +45,13 @@ static int xilinxphy_startup(struct phy_device *phydev)
 
 	if (AUTONEG_ENABLE == phydev->autoneg) {
 		status = phy_read(phydev, MDIO_DEVAD_NONE, MII_LPA);
-		status = status & MII_PHY_STATUS_SPD_MASK;
 
 		if (status & MII_PHY_STATUS_FULLDUPLEX)
 			phydev->duplex = DUPLEX_FULL;
 		else
 			phydev->duplex = DUPLEX_HALF;
 
+		status = status & MII_PHY_STATUS_SPD_MASK;
 		switch (status) {
 		case MII_PHY_STATUS_1000:
 			phydev->speed = SPEED_1000;


### PR DESCRIPTION
For SGMII in-band auto-negotiation, the negotiated speed and duplex are reported in MII_LPA (register 5).

The current code masks the speed bits from MII_LPA before evaluating the duplex bit, which clears the FULLDUPLEX flag and causes full-duplex links to be incorrectly parsed as half-duplex.

Fix this by parsing the duplex bit before applying the speed mask.

Please do not submit a Pull Request via github.  Our project makes use of
mailing lists for patch submission and review.  For more details please
see https://u-boot.readthedocs.io/en/latest/develop/sending_patches.html

The only exception to this is in order to trigger a CI loop on Azure prior
to posting of patches.

If your patch targets the Xilinx U-Boot repository please send a patch to git@amd.com.
